### PR TITLE
Added a call to 'npm run build' in assemble script

### DIFF
--- a/nodejs.org/s2i/bin/assemble
+++ b/nodejs.org/s2i/bin/assemble
@@ -51,5 +51,11 @@ fi
 echo "---> Building your Node application from source"
 npm install -d
 
+# Only run the build script if one is present
+if [[ ! -z `npm run env | cut -d'=' -f1 | grep '^npm_package_scripts_build$'` ]]; then
+	echo "---> Running the npm package build script"
+	npm run build
+fi
+
 # Fix source directory permissions
 fix-permissions ./


### PR DESCRIPTION
For many use cases, it is convenient (and somethimes necessary) to have a script called at build time. We should do something in the assemble script to support these cases. As such, I have added a few lines that detects if the package defines a build script, and will call it if it does.